### PR TITLE
Add "use_dynamic_url" to prevent browser fingerprinting

### DIFF
--- a/manifest-chromium.json
+++ b/manifest-chromium.json
@@ -36,7 +36,8 @@
         "favicons/*",
         "data/data.json"
       ],
-      "matches": ["https://*/*", "http://*/*"]
+      "matches": ["https://*/*", "http://*/*"],
+      "use_dynamic_url": true
     }
   ],
   "background": {

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -26,7 +26,8 @@
         "favicons/*",
         "data/data.json"
       ],
-      "matches": ["https://*/*", "http://*/*"]
+      "matches": ["https://*/*", "http://*/*"],
+      "use_dynamic_url": true
     }
   ],
   "background": {

--- a/scripts/content-banners.js
+++ b/scripts/content-banners.js
@@ -1,4 +1,6 @@
-import {
+export {}; // keep this so that we can use top-level await
+
+const {
   extensionAPI,
   getUserSettings,
   setUserSetting,
@@ -9,7 +11,7 @@ import {
   makeKeyboardButton,
   normalizeBreezewikiHost,
   pickBreezewikiHost,
-} from "./common-functions.js";
+} = await import(browser.runtime.getURL("scripts/common-functions.js"));
 
 const currentURL = new URL(document.location);
 

--- a/scripts/content-search-filtering.js
+++ b/scripts/content-search-filtering.js
@@ -1,6 +1,8 @@
 // @ts-check
 
-import {
+export {}; // keep this so that we can use top-level await
+
+const {
   extensionAPI,
   getUserSettings,
   findMatchingSite,
@@ -14,7 +16,8 @@ import {
   makeKeyboardButton,
   safeDecodeURI,
   safeDecodeURIComponent,
- } from './common-functions.js';
+ // @ts-ignore: browser.runtime API is available in extension scripts
+ } = await import(browser.runtime.getURL('scripts/common-functions.js'));
 
 /**
  * @typedef {import('./common-functions').SiteData} SiteData


### PR DESCRIPTION
This extension is easily detected even outside of pages that the extension doesn't have permissions in. For example, this page detects the extension: https://browserleaks.com/chrome

To prevent this, this PR adds the "use_dynamic_url" option in the manifest.json, and changes the script imports to dynamic imports.

To check if this works on Chromium, open a console window and type `await fetch('chrome-extension://EXTENSION_ID_GOES_HERE/scripts/common-functions.js')`. Don't use the page I linked above for testing, as the extension ID is probably going to be different for local builds. It also seems to be working on Firefox, but it was with a temporary extension, so I don't know how valid the test is (use `moz-extension` instead of `chrome-extension`, the extension itself is working).

I'm not used to extension development, so please let me know if I missed anything. For example, I had to add a ts-ignore due to the use of browser.runtime.getURL, but I don't know if that's a problem with my IDE since there are other Typescript errors that were already here (e.g. String.replaceAll)